### PR TITLE
Feature/Add the file block

### DIFF
--- a/src/components/NotionBlocks.astro
+++ b/src/components/NotionBlocks.astro
@@ -26,6 +26,7 @@ import NumberedListItems from './notion-blocks/NumberedListItems.astro'
 import ToDo from './notion-blocks/ToDo.astro'
 import SyncedBlock from './notion-blocks/SyncedBlock.astro'
 import Toggle from './notion-blocks/Toggle.astro'
+import File from './notion-blocks/File.astro'
 
 export interface Props {
   blocks: interfaces.Block[]
@@ -162,6 +163,8 @@ const bookmarkURLMap = await buildURLToHTMLMap(bookmarkURLs)
       return <SyncedBlock block={block} headings={headings} />
     case 'toggle':
       return <Toggle block={block} headings={headings} />
+    case 'file':
+      return <File block={block} />
   }
   return null
   })}

--- a/src/components/notion-blocks/File.astro
+++ b/src/components/notion-blocks/File.astro
@@ -9,8 +9,8 @@ const { block } = Astro.props
 let url: URL;
 let fileName: string = 'File';
 try {
-  url = new URL(block.File?.Url)
-  fileName = block.File?.Url.match(".+/(.+?)([\?#;].*)?$")[1];
+  url = new URL(block.FileBlock.File.External.Url)
+  fileName = block.FileBlock.File.External.Url.match(".+/(.+?)([\?#;].*)?$")[1];
 } catch (err) {
   console.error(err)
 }

--- a/src/components/notion-blocks/File.astro
+++ b/src/components/notion-blocks/File.astro
@@ -1,0 +1,26 @@
+---
+import * as interfaces from '../../lib/interfaces.ts'
+export interface Props {
+  block: interfaces.Block
+}
+
+const { block } = Astro.props
+
+let url: URL;
+let fileName: string = 'File';
+try {
+  url = new URL(block.File?.Url)
+  fileName = block.File?.Url.match(".+/(.+?)([\?#;].*)?$")[1];
+} catch (err) {
+  console.error(err)
+}
+---
+
+<div class="file">
+  <div>
+    {url && (<p><a href={url} target="_blank">&#128229; {fileName}</a></p>)}
+  </div>
+</div>
+
+<style>
+</style>

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -107,12 +107,13 @@ export interface File {
 export interface FileBlock {
   Type: string
   File: {
-    External: File
+    External: External
   }
 }
 
 export interface External {
   Url: string
+  ExpiryTime?: string
 }
 
 export interface Code {

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -106,7 +106,9 @@ export interface File {
 
 export interface FileBlock {
   Type: string
-  File: File
+  File: {
+    External: File
+  }
 }
 
 export interface External {

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -35,7 +35,7 @@ export interface Block {
   Table?: Table
   ColumnList?: ColumnList
   TableOfContents?: TableOfContents
-  File?: File
+  FileBlock?: FileBlock
 }
 
 export interface Paragraph {
@@ -102,6 +102,11 @@ export interface Video {
 export interface File {
   Url: string
   ExpiryTime?: string
+}
+
+export interface FileBlock {
+  Type: string
+  File: File
 }
 
 export interface External {

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -35,6 +35,7 @@ export interface Block {
   Table?: Table
   ColumnList?: ColumnList
   TableOfContents?: TableOfContents
+  File?: File
 }
 
 export interface Paragraph {

--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -38,7 +38,7 @@ import type {
   Text,
   Annotation,
   SelectProperty,
-  File,
+  FileBlock,
 } from '../interfaces'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 import { Client } from '@notionhq/client'
@@ -232,6 +232,10 @@ export async function getAllBlocksByBlockId(blockId: string): Promise<Block[]> {
     } else if (block.Type === 'image' && block.Image && block.Image.File && block.Image.File.ExpiryTime) {
       if (Date.parse(block.Image.File.ExpiryTime) < Date.now()) {
         block.Image = (await getBlock(block.Id)).Image
+      }
+    } else if (block.Type === 'file' && block.FileBlock && block.FileBlock.File && block.FileBlock.File.ExpiryTime) {
+      if (Date.parse(block.FileBlock.File.ExpiryTime) < Date.now()) {
+        block.FileBlock = (await getBlock(block.Id)).FileBlock
       }
     }
   }
@@ -478,10 +482,15 @@ function _buildBlock(blockObject: responses.BlockObject): Block {
       break
     case 'file':
       if (blockObject.file?.file) {
-        const file: File = {
-          Url: blockObject.file.file.url,
+        const FileBlock: FileBlock = {
+          Type: blockObject.file.type,
+          File: {
+            External: {
+              Url: blockObject.file.file.url
+            }
+          }
         }
-        block.File = file
+        block.FileBlock = FileBlock
       }
       break
   }

--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -233,8 +233,8 @@ export async function getAllBlocksByBlockId(blockId: string): Promise<Block[]> {
       if (Date.parse(block.Image.File.ExpiryTime) < Date.now()) {
         block.Image = (await getBlock(block.Id)).Image
       }
-    } else if (block.Type === 'file' && block.FileBlock && block.FileBlock.File && block.FileBlock.File.ExpiryTime) {
-      if (Date.parse(block.FileBlock.File.ExpiryTime) < Date.now()) {
+    } else if (block.Type === 'file' && block.FileBlock && block.FileBlock.File && block.FileBlock.File.External.ExpiryTime) {
+      if (Date.parse(block.FileBlock.File.External.ExpiryTime) < Date.now()) {
         block.FileBlock = (await getBlock(block.Id)).FileBlock
       }
     }

--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -38,6 +38,7 @@ import type {
   Text,
   Annotation,
   SelectProperty,
+  File,
 } from '../interfaces'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 import { Client } from '@notionhq/client'
@@ -473,6 +474,14 @@ function _buildBlock(blockObject: responses.BlockObject): Block {
           Color: blockObject.table_of_contents.color,
         }
         block.TableOfContents = tableOfContents
+      }
+      break
+    case 'file':
+      if (blockObject.file?.file) {
+        const file: File = {
+          Url: blockObject.file.file.url,
+        }
+        block.File = file
       }
       break
   }

--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -486,7 +486,8 @@ function _buildBlock(blockObject: responses.BlockObject): Block {
           Type: blockObject.file.type,
           File: {
             External: {
-              Url: blockObject.file.file.url
+              Url: blockObject.file.file.url,
+              ExpiryTime: blockObject.file.file.expiry_time
             }
           }
         }


### PR DESCRIPTION
先ほどはファイル期限についてアドバイスいただきありがとうございました🙏
Fileブロックを表示できるようにしました。

Notionのネイティブアプリのように、ファイル名をクリックでダウンロードさせたかったのですが、ウェブでは同一ドメイン間でないとダウンロードさせられない仕様とのことで、ファイル名をクリックすると別窓でリンク先のファイルが開きます。
<img width="400" alt="SCR-20230212-o1m" src="https://user-images.githubusercontent.com/4230465/218302159-13b593a9-02b7-49cb-8a5e-22ed4d37033d.png">

アイコンは絵文字で対応しました。
もし今後、Notionの純正のIcons↓等に対応するようでしたら（できるのかは謎です・汗）、そのバリエーションからもっと適切なアイコンに差し替えても良いと思います。
<img width="402" alt="SCR-20230212-p7n" src="https://user-images.githubusercontent.com/4230465/218302314-ae6ea8e0-1fc8-4d56-86e1-7520b23f3bda.png">