### PR TITLE
[fix] Safari での表示崩れを修正

### DIFF
--- a/src/components/notion-blocks/LinkToPage.astro
+++ b/src/components/notion-blocks/LinkToPage.astro
@@ -45,7 +45,6 @@ if (block.LinkToPage.Type === 'page_id') {
     gap: 4px;
   }
   .icon {
-    width: 1em;
     height: fit-content;
     flex-shrink: 0;
     position: relative;


### PR DESCRIPTION
さきほどは Link to Page ブロックのプルリクをマージいただきありがとうございました！
大変申し訳ないのですが、Safariでの微妙な表示崩れを発見しました。
該当行を消せば適切に表示されます 🙇 

Before
<img width="718" alt="safari-before" src="https://user-images.githubusercontent.com/4230465/221398526-27b98084-1f01-480f-b62d-3e6e37b5f982.png">

After
<img width="653" alt="safari-after" src="https://user-images.githubusercontent.com/4230465/221398532-480a11cd-2118-4f7f-9fe9-edb2e1e7e93e.png">