### PR TITLE
[fix] getPostLinkを使ってリンク先ページのURLを取得

### DIFF
--- a/src/components/notion-blocks/LinkToPage.astro
+++ b/src/components/notion-blocks/LinkToPage.astro
@@ -1,8 +1,10 @@
 ---
 import * as interfaces from '../../lib/interfaces.ts'
 import { getPostByPageId } from '../../lib/notion/client'
+import { getPostLink } from '../../lib/blog-helpers.ts'
 import '../../styles/notion-color.css'
 import arrow from '../../images/icon-arrow-link.svg'
+
 export interface Props {
   block: interfaces.Block
 }
@@ -17,7 +19,7 @@ if (block.LinkToPage.Type === 'page_id') {
 {
   post ? (
     <p>
-      <a href={`${post.Slug}`} class="link">
+      <a href={`${getPostLink(post.Slug)}`} class="link">
         <span class="icon">
           {post.Icon.Emoji ? post.Icon.Emoji : '📄'}
           <img src={arrow} class="icon-link" alt="" />


### PR DESCRIPTION
Twitter にてご報告いただいた下記の件の修正です。

> どこで伝えたら良いか分からなかったので、ここに送らせてもらいます、すみません！ 取り込んで使わせていただいたんですが、リンクしたページリンクをクリックすると、リンクがおかしくなってトップ画面に飛ばされてしまうんですが、バグでしょうか？（サンプルページでも確認できます）
https://twitter.com/snk_skr/status/1629866119258591237

私の環境では設定のせいか、ローカルでもデプロイ後も遷移できてしまっていたため気付かず失礼いたしました 🙇 
ブログ記事のURLの末尾にスラッシュがあったりなかったりすることで、参照先のディレクトリが変わってしまうために起きた現象でした。
`getPostLink()`を使ってURLを取得するように変更いたしましたので、こちらで直るかと思います。