### PR TITLE
move Google Analytics tag inside head

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,6 +49,7 @@ const asidePaddingTop = coverImageURL ? '200px' : '60px'
 <!DOCTYPE html>
 <html lang="en" prefix="og: https://ogp.me/ns#">
   <head>
+    <GoogleAnalytics trackingId={PUBLIC_GA_TRACKING_ID} />  
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="max-image-preview:large" />
     <meta charset="UTF-8" />
@@ -73,7 +74,6 @@ const asidePaddingTop = coverImageURL ? '200px' : '60px'
     />
   </head>
   <body>
-    <GoogleAnalytics trackingId={PUBLIC_GA_TRACKING_ID} />
     <div class="container">
       <main>
         {


### PR DESCRIPTION
GAの推奨が `<head>` の直後なので、それに合わせてみました。
![image](https://user-images.githubusercontent.com/48118431/224233461-48232ea2-cb40-4d7d-b0cb-b299d296e321.png)