### PR TITLE
add BASE_PATH to downloaded image link

### DIFF
--- a/src/lib/blog-helpers.ts
+++ b/src/lib/blog-helpers.ts
@@ -12,7 +12,7 @@ import { pathJoin } from './utils'
 
 export const filePath = (url: URL): string => {
   const [dir, filename] = url.pathname.split('/').slice(-2)
-  return `/notion/${dir}/${filename}`
+  return pathJoin(BASE_PATH, `/notion/${dir}/${filename}`)
 }
 
 export const extractTargetBlocks = (


### PR DESCRIPTION
Notion の画像はこれまで external link のみを使っていました。今日ブログを始めるにあたって初めてアップロードした画像を使ったのですが、デプロイしたら画像がリンク切れになっていました。こちらも pathJoin するか、getStaticFilePath のどちらかが必要かと思います。

とりあえず pathJoin の方でプルリクエストを作りましたが、getStaticFilePath の方がよいようであればそちらに変換します。