### PR TITLE
Add URL decoding to japanese filename

### DIFF
--- a/src/components/notion-blocks/File.astro
+++ b/src/components/notion-blocks/File.astro
@@ -16,7 +16,7 @@ try {
   console.error(`Invalid file URL. error: ${err}`)
 }
 
-const filename = url.pathname.split('/').slice(-1)[0]
+const filename = decodeURIComponent(url.pathname.split('/').slice(-1)[0])
 ---
 
 <div class="file">


### PR DESCRIPTION
ファイルブロックのファイル名がURLデコードされていないため、日本語のときに正しい表示にならない問題を修正しました。
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/2f6c53e5-d50d-40bb-888d-f12a14cbed67)
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/2ad95fe2-169c-4176-ab39-0c3aaaccd2fd)
