### PR TITLE
Change code annotations background color

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -420,7 +420,7 @@ if (database.Icon && database.Icon.Type === 'file') {
 
   code {
     font-size: 0.9rem;
-    background: #f1f1f1;
+    background: rgba(135, 131, 120, 0.15);
     color: #eb5757;
     padding: 0.25rem;
     border-radius: var(--radius);


### PR DESCRIPTION
codeの背景色を透明度付きに変更し、コールアウト等の色があるブロック上にあるときには、Notionと同じように色が変わるようにしました。

左がastro-notion-blog、右がブラウザ版Notionです。
変更前
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/27d97b75-a378-49ff-bc21-98a847d76e65)
変更後
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/a6a3a25b-cd23-45d3-9ee8-55bc878ef42d)
カラーピッカーで重なって混ざった後の色の一致を確認済みです。