### PR TITLE
Add Codeblock horizontal scroll

### DIFF
--- a/src/components/notion-blocks/Code.astro
+++ b/src/components/notion-blocks/Code.astro
@@ -78,6 +78,7 @@ const grammer =
   .code {
     display: block;
     width: 100%;
+    margin-bottom: 0.6rem;
   }
   .code > div {
     background: rgb(247, 246, 243);
@@ -103,7 +104,19 @@ const grammer =
     padding: 0.8rem 2rem 2rem;
     font-size: 0.9rem;
     line-height: 1.2rem;
-    white-space: pre-wrap;
+    white-space: pre;
+    width: 100px;
+    min-width: 100%;
+    overflow-x: auto;
+    &::-webkit-scrollbar {
+      height: 10px;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: rgb(211, 209, 203);
+    }
+    &::-webkit-scrollbar-track {
+      background: rgb(237, 236, 233);
+    }
   }
   .code pre.mermaid {
     padding: 2rem;


### PR DESCRIPTION
コードブロックの折返しを無くし、はみ出す分はNotionのように横スクロールできるようにしました。
また、margin-bottomを少し付けました。デザインは極力Notionに近づけています。
Chrome系、Firefox、Edge、iPadのSafariで動作を確かめてあります。

左がastro-notion-blog、右がブラウザ版Notionです。
変更前
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/888774f2-2fa7-439f-a9f3-8b27ebacf0a2)
変更後
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/9bd9386b-7641-4193-a768-0dfff5f683bf)