### PR TITLE
Support CodePen embed

### DIFF
--- a/src/components/notion-blocks/CodePenEmbed.astro
+++ b/src/components/notion-blocks/CodePenEmbed.astro
@@ -1,0 +1,26 @@
+---
+export interface Props {
+  url: string
+}
+const { url } = Astro.props
+const user = url.pathname.split('/')[1]
+const id = url.pathname.split('/')[3]
+---
+
+<div class="codepen-embed">
+  <p
+    class="codepen"
+    data-height="500"
+    data-slug-hash={id.toString()}
+    data-user={user.toString()}
+    style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;"
+  >
+  </p>
+</div>
+<script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
+
+<style>
+  .codepen-embed {
+    background-color: #fff;
+  }
+</style>

--- a/src/components/notion-blocks/Embed.astro
+++ b/src/components/notion-blocks/Embed.astro
@@ -5,12 +5,14 @@ import {
   isTikTokURL,
   isInstagramURL,
   isPinterestURL,
+  isCodePenURL,
 } from '../../lib/blog-helpers.ts'
 import Bookmark from './Bookmark.astro'
 import TweetEmbed from './TweetEmbed.astro'
 import TikTokEmbed from './TikTokEmbed.astro'
 import InstagramEmbed from './InstagramEmbed.astro'
 import PinterestEmbed from './PinterestEmbed.astro'
+import CodePenEmbed from './CodePenEmbed.astro'
 
 export interface Props {
   block: interfaces.Block
@@ -37,6 +39,8 @@ try {
       <InstagramEmbed url={url} />
     ) : isPinterestURL(url) ? (
       <PinterestEmbed url={url} />
+    ) : isCodePenURL(url) ? (
+      <CodePenEmbed url={url} />
     ) : (
       <Bookmark block={block} urlMap={urlMap} />
     )

--- a/src/lib/blog-helpers.ts
+++ b/src/lib/blog-helpers.ts
@@ -220,6 +220,13 @@ export const isPinterestURL = (url: URL): boolean => {
   return /\/pin\/[\d]+/.test(url.pathname)
 }
 
+export const isCodePenURL = (url: URL): boolean => {
+  if (url.hostname !== 'codepen.io' && url.hostname !== 'www.codepen.io') {
+    return false
+  }
+  return /\/[^/]+\/pen\/[^/]+/.test(url.pathname)
+}
+
 export const isShortAmazonURL = (url: URL): boolean => {
   if (url.hostname === 'amzn.to' || url.hostname === 'www.amzn.to') {
     return true


### PR DESCRIPTION
CodePenの埋め込み機能を作りました。
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/b47898c2-68e8-46a7-b2bb-b315b66aa73a)
Notion上での挙動がそうなのですが、ダークテーマ等の濃い背景色ではクレジット表記に斜めの透過線が入っていて可読性が損なわれてしまうため、
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/05160009-cf35-4539-8455-0aa79dd59730)
このようにCodePenに白い背景を常に設定するようにしてあります。
![CodePen埋め込み背景上書き](https://github.com/otoyo/astro-notion-blog/assets/47468734/460dd2ff-168f-4b19-91b1-4dc69db1d354)