### PR TITLE
Fix Codepen and Caption

### DIFF
--- a/src/components/notion-blocks/Caption.astro
+++ b/src/components/notion-blocks/Caption.astro
@@ -19,5 +19,8 @@ const { richTexts } = Astro.props
     margin-top: 0.3rem;
     font-size: 0.9rem;
     color: var(--accents-3);
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.4;
   }
 </style>

--- a/src/components/notion-blocks/CodePenEmbed.astro
+++ b/src/components/notion-blocks/CodePenEmbed.astro
@@ -7,20 +7,22 @@ const user = url.pathname.split('/')[1]
 const id = url.pathname.split('/')[3]
 ---
 
-<div class="codepen-embed">
-  <p
-    class="codepen"
-    data-height="500"
-    data-slug-hash={id.toString()}
-    data-user={user.toString()}
-    style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;"
-  >
-  </p>
-</div>
+<p
+  class="codepen"
+  data-slug-hash={id.toString()}
+  data-user={user.toString()}
+  style="box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;"
+>
+</p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-<style>
-  .codepen-embed {
+<style is:global>
+  .cp_embed_wrapper {
+    width: 100%;
+    aspect-ratio: 1.6 / 1;
     background-color: #fff;
+  }
+  .cp_embed_wrapper iframe {
+    height: 100% !important;
   }
 </style>


### PR DESCRIPTION
Codepen埋め込みにアスペクト比維持を追加しました。

また、Caption内での改行を有効化しました。
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/47568e8b-a072-4c22-9cc1-2a02519ca604)
有効化後↓
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/532b6725-effa-48aa-b843-bafcf0ea8887)

しかし、メインカラムの横幅よりも小さい画像の下に画像の横幅よりも長いキャプションを書くと、キャプションが画像の横幅をはみ出してfigure要素の横幅となってしまい、画像がどんどん左に寄ってしまう点については修正できませんでした。
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/bc713ba0-4dbd-4d61-b0ed-8d76a1906724)
↓これはNotionです。
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/07447be4-5f93-4d5d-abd1-f81eab78bb03)
こちらはIsuuesに追加させていただきます。