### PR TITLE
Fix Caption line brake and overflow

### DIFF
--- a/src/components/notion-blocks/Caption.astro
+++ b/src/components/notion-blocks/Caption.astro
@@ -10,17 +10,24 @@ const { richTexts } = Astro.props
 
 {
   richTexts.length > 0 && richTexts[0].Text.Content && (
-    <div class="caption">{richTexts[0].Text.Content}</div>
+    <div class="caption">
+      <div>{richTexts[0].Text.Content}</div>
+    </div>
   )
 }
 
 <style>
   .caption {
+    display: flex;
     margin-top: 0.3rem;
     font-size: 0.9rem;
     color: var(--accents-3);
     white-space: pre-wrap;
     word-break: break-word;
     line-height: 1.4;
+  }
+  .caption > div {
+    flex-grow: 1;
+    width: 0;
   }
 </style>

--- a/src/components/notion-blocks/Caption.astro
+++ b/src/components/notion-blocks/Caption.astro
@@ -19,5 +19,8 @@ const { richTexts } = Astro.props
     margin-top: 0.3rem;
     font-size: 0.9rem;
     color: var(--accents-3);
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.4;
   }
 </style>


### PR DESCRIPTION
Issues：https://github.com/otoyo/astro-notion-blog/issues/174
方法：https://stackoverflow.com/questions/9769587/set-div-to-have-its-siblings-width

キャプションの途中改行を有効にしました。
また、小さい画像の横幅を超えるキャプションの文章を自動で折り返すようになりました。
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/9be357f2-e152-46d7-b6fa-a8214a448920)
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/b0e99176-b32e-4e0a-90b4-7732d6a16c66)
