### PR TITLE
fix TikTok embed

### DIFF
--- a/src/components/notion-blocks/TikTokEmbed.astro
+++ b/src/components/notion-blocks/TikTokEmbed.astro
@@ -30,5 +30,11 @@ const videoId = url.pathname.split('/')[3]
   .tiktok-wrapper {
     max-width: 325px;
     overflow-x: auto;
+    margin-block-start: 1.5rem;
+    margin-inline: auto;
+    border-radius: 8px;
+  }
+  blockquote.tiktok-embed {
+    margin: 0;
   }
 </style>

--- a/src/components/notion-blocks/TikTokEmbed.astro
+++ b/src/components/notion-blocks/TikTokEmbed.astro
@@ -7,19 +7,27 @@ const user = url.pathname.split('/')[1]
 const videoId = url.pathname.split('/')[3]
 ---
 
-<blockquote
-  class="tiktok-embed"
-  cite={url.toString()}
-  data-video-id={videoId}
-  style="max-width: 605px;min-width: 325px;"
->
-  <section>
-    <a
-      target="_blank"
-      title={user}
-      href="https://www.tiktok.com/{user}?refer=embed">{user}</a
-    >
-  </section>
-</blockquote>
+<div class="tiktok-wrapper">
+  <blockquote
+    class="tiktok-embed"
+    cite={url.toString()}
+    data-video-id={videoId}
+    style="min-width: 325px;"
+  >
+    <section>
+      <a
+        target="_blank"
+        title={user}
+        href="https://www.tiktok.com/{user}?refer=embed">{user}</a
+      >
+    </section>
+  </blockquote>
+</div>
 
 <script async src="https://www.tiktok.com/embed.js"></script>
+
+<style>
+  .tiktok-wrapper {
+    max-width: 325px;
+  }
+</style>

--- a/src/components/notion-blocks/TikTokEmbed.astro
+++ b/src/components/notion-blocks/TikTokEmbed.astro
@@ -29,5 +29,6 @@ const videoId = url.pathname.split('/')[3]
 <style>
   .tiktok-wrapper {
     max-width: 325px;
+    overflow-x: auto;
   }
 </style>

--- a/src/components/notion-blocks/TikTokEmbed.astro
+++ b/src/components/notion-blocks/TikTokEmbed.astro
@@ -18,27 +18,6 @@ const videoId = url.pathname.split('/')[3]
       target="_blank"
       title={user}
       href="https://www.tiktok.com/{user}?refer=embed">{user}</a
-    ><a
-      title="foryoupage"
-      target="_blank"
-      href="https://www.tiktok.com/tag/foryoupage?refer=embed">#foryoupage</a
-    >
-    <a
-      title="petsoftiktok"
-      target="_blank"
-      href="https://www.tiktok.com/tag/petsoftiktok?refer=embed"
-      >#petsoftiktok</a
-    >
-    <a
-      title="aesthetic"
-      target="_blank"
-      href="https://www.tiktok.com/tag/aesthetic?refer=embed">#aesthetic</a
-    >
-    <a
-      target="_blank"
-      title="♬ original sound - tiff"
-      href="https://www.tiktok.com/music/original-sound-6689804660171082501?refer=embed"
-      >♬ original sound - tiff</a
     >
   </section>
 </blockquote>


### PR DESCRIPTION
TikTok埋め込みはサイズが固定値となっており、メインカラムの横幅がおよそ325pxを超えると余った部分に白い背景が描写されていました。
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/644676a1-5742-4ac7-99b8-9bfc707af7c5)

埋め込み内部のもの(映像やキャプション)はメインカラムが325px以下となっても自動的に縮小されず、メインカラムを突き破ってしまうため、ギリギリのサイズで最小幅を指定したラッパーで囲い、はみ出した分はoverflow-xで隠して横スクロールで表示するようにしました。
![image](https://github.com/otoyo/astro-notion-blog/assets/47468734/05a6d107-9afc-4e66-bf46-86023103955e)

![TikTokembed2](https://github.com/otoyo/astro-notion-blog/assets/47468734/15012c8e-c52a-421f-9b54-5aa9d64e19e1)
