### PR TITLE
Fixed getNavLink to follow trailingSlash:never in astro.config.mjs.

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'astro/config';
-import { CUSTOM_DOMAIN, BASE_PATH } from './src/server-constants';
+import { CUSTOM_DOMAIN, BASE_PATH, TRAILING_SLASH } from './src/server-constants';
 import CoverImageDownloader from './src/integrations/cover-image-downloader';
 import CustomIconDownloader from './src/integrations/custom-icon-downloader';
 import FeaturedImageDownloader from './src/integrations/featured-image-downloader';
@@ -35,6 +35,7 @@ const getSite = function () {
 export default defineConfig({
   site: getSite(),
   base: BASE_PATH,
+  trailingSlash: TRAILING_SLASH,
   integrations: [
     CoverImageDownloader(),
     CustomIconDownloader(),

--- a/src/lib/blog-helpers.ts
+++ b/src/lib/blog-helpers.ts
@@ -9,6 +9,7 @@ import type {
   Column,
 } from './interfaces'
 import { pathJoin } from './utils'
+import defineConfig from '../../astro.config.mjs'
 
 export const filePath = (url: URL): string => {
   const [dir, filename] = url.pathname.split('/').slice(-2)
@@ -124,7 +125,7 @@ export const getStaticFilePath = (path: string): string => {
 
 export const getNavLink = (nav: string) => {
   if ((!nav || nav === '/') && BASE_PATH) {
-    return pathJoin(BASE_PATH, '') + '/'
+    return pathJoin(BASE_PATH, '') + (defineConfig.trailingSlash === 'never' ? '' : '/')
   }
 
   return pathJoin(BASE_PATH, nav)

--- a/src/lib/blog-helpers.ts
+++ b/src/lib/blog-helpers.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch'
-import { BASE_PATH, REQUEST_TIMEOUT_MS } from '../server-constants'
+import { BASE_PATH, REQUEST_TIMEOUT_MS, TRAILING_SLASH } from '../server-constants'
 import type {
   Block,
   Heading1,
@@ -9,7 +9,6 @@ import type {
   Column,
 } from './interfaces'
 import { pathJoin } from './utils'
-import defineConfig from '../../astro.config.mjs'
 
 export const filePath = (url: URL): string => {
   const [dir, filename] = url.pathname.split('/').slice(-2)
@@ -125,7 +124,7 @@ export const getStaticFilePath = (path: string): string => {
 
 export const getNavLink = (nav: string) => {
   if ((!nav || nav === '/') && BASE_PATH) {
-    return pathJoin(BASE_PATH, '') + (defineConfig.trailingSlash === 'never' ? '' : '/')
+    return pathJoin(BASE_PATH, '') + (TRAILING_SLASH === 'never' ? '' : '/')
   }
 
   return pathJoin(BASE_PATH, nav)

--- a/src/server-constants.ts
+++ b/src/server-constants.ts
@@ -7,6 +7,8 @@ export const CUSTOM_DOMAIN =
   import.meta.env.CUSTOM_DOMAIN || process.env.CUSTOM_DOMAIN || '' // <- Set your costom domain if you have. e.g. alpacat.com
 export const BASE_PATH =
   import.meta.env.BASE_PATH || process.env.BASE_PATH || '' // <- Set sub directory path if you want. e.g. /docs/
+export const TRAILING_SLASH =
+  import.meta.env.TRAILING_SLASH || process.env.TRAILING_SLASH || 'always' // <- Set "never" | "always" | "ignore".
 
 export const PUBLIC_GA_TRACKING_ID = import.meta.env.PUBLIC_GA_TRACKING_ID
 export const NUMBER_OF_POSTS_PER_PAGE = 10


### PR DESCRIPTION
サブパスで運用する際にastro側でTrailing Slashを非表示にすると一部でリンク切れが発生するため、
astro.config.mjsのtrailingSlash: 'never'へ追従する修正案になります。

**再現方法**
1.  /src/server-constrants.tsのBASE_PATHを設定 (ここでは仮に/blog/とします。)
3. astro.config.mjsのdefineConfigにてtrailingSlash: 'never'を設定
4. astroは/blog、/src/lib/blog-helpers.tsのgetNavLink()は/blog/を前提とした不整合が発生

**確認したリンク切れ発生個所**
 - トップページ タイトルのリンク
 - トップページのlink rel="canonical"のリンク
 - 各ポストの[↑TOPへ]のリンク