### PR TITLE
Mentionの矢印が表示されていない問題を修正

### DIFF
--- a/src/components/notion-blocks/Mention.astro
+++ b/src/components/notion-blocks/Mention.astro
@@ -33,7 +33,7 @@ if (pageId) {
           ) : (
             '📄'
           )}
-          <img src={arrow} class="icon-link" alt="Arrow icon of a page link" />
+          <img src={arrow.src} class="icon-link" alt="Arrow icon of a page link" />
         </span>
         <span class="text">{post.Title}</span>
       </>
@@ -42,7 +42,7 @@ if (pageId) {
     <a class="link">
       <span class="icon">
         🚫
-        <img src={arrow} class="icon-link" alt="Arrow icon of a page link" />
+        <img src={arrow.src} class="icon-link" alt="Arrow icon of a page link" />
       </span>
       <span class="text not-found">Post not found</span>
     </a>


### PR DESCRIPTION
前回は画像ダウンロードに関する問題を修正して頂きありがとうございました。
メンションブロックの矢印画像のパスが誤っており、表示されていない問題を見つけましたのでPRを送ります。

## 問題の詳細

矢印画像が表示されていない
<img width="168" alt="image" src="https://github.com/otoyo/astro-notion-blog/assets/4524414/6e57768b-6cc8-437e-a325-9cb4f2238234">

`.src` が無いためobjectが渡されている
```
<img src="[object Object]" class="icon-link" alt="Arrow icon of a page link" data-astro-cid-63pa2ukg="">
```