### PR TITLE
Fix empty icon Callout selector

### DIFF
--- a/src/components/notion-blocks/Callout.astro
+++ b/src/components/notion-blocks/Callout.astro
@@ -53,14 +53,14 @@ const { block, headings } = Astro.props
     border-color: transparent;
     background: rgba(235, 236, 237, 0.6);
   }
-  .callout div {
+  .callout > div {
     margin: 0;
     line-height: 1.5rem;
   }
-  .callout div:first-child {
+  .callout > div.icon {
     margin-right: 0.7rem;
   }
-  .callout div:first-child img {
+  .callout > div.icon > img {
     width: 1.2rem;
     height: 1.2rem;
   }

--- a/src/components/notion-blocks/Callout.astro
+++ b/src/components/notion-blocks/Callout.astro
@@ -15,7 +15,7 @@ const { block, headings } = Astro.props
 <div class={`callout ${snakeToKebab(block.Callout.Color)}`}>
   {
     block.Callout.Icon && (
-      <div>
+      <div class="icon">
         {block.Callout.Icon.Type === 'emoji' ? (
           block.Callout.Icon.Emoji
         ) : block.Callout.Icon.Type === 'external' ? (


### PR DESCRIPTION
コールアウトからアイコンを削除すると、アイコンに適用するmargin-rightがテキスト部に適用されていました。
![3](https://github.com/otoyo/astro-notion-blog/assets/47468734/3f32ef9a-1679-4980-832b-01b679c25dec)
![5](https://github.com/otoyo/astro-notion-blog/assets/47468734/9257e692-6e2a-484d-9eee-17248b435c78)
![7](https://github.com/otoyo/astro-notion-blog/assets/47468734/0c4992a7-438a-4622-9ae2-3b5c93c047e2)

アイコンを包むdiv要素にクラス名をつけ、CSSのセレクタでアイコンのみを指定するように適用範囲を絞りました。
![1](https://github.com/otoyo/astro-notion-blog/assets/47468734/c22ae988-c58b-4967-8934-6092f6f949b9)