### PR TITLE
fix: remove node-fetch

### DIFF
--- a/src/lib/blog-helpers.ts
+++ b/src/lib/blog-helpers.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch'
 import { BASE_PATH, REQUEST_TIMEOUT_MS } from '../server-constants'
 import type {
   Block,


### PR DESCRIPTION
node-fetch is not declared in the package.json, but it is still being used as a phantom dependency in the code

If you use a package manager like pnpm that does not support phantom dependencies, or other versions of npm that do not hoist dependencies, this will result in a build failure