### PR TITLE
Fix template literal syntax in [slug].astro

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -35,7 +35,7 @@ const { slug } = Astro.params
 
 const post = await getPostBySlug(slug)
 if (!post) {
-  throw new Error('Post not found. slug: ${slug}')
+  throw new Error(`Post not found. slug: ${slug}`)
 }
 
 const [blocks, allPosts, rankedPosts, recentPosts, tags, postsHavingSameTag] =


### PR DESCRIPTION
動的ルーティングの勉強のために[slug].astroを読み込んでいたところ、シンタックスハイライトの違和感に気づき、エラーメッセージのテンプレートリテラルを修正しました。

また、リポジトリ内を"${"で検索して${ }が使われている箇所を全てチェックしましたが、他に修正が必要な箇所は無いようです。