### PR TITLE
Fix CodePenEmbed Props url type from string to URL

### DIFF
--- a/src/components/notion-blocks/CodePenEmbed.astro
+++ b/src/components/notion-blocks/CodePenEmbed.astro
@@ -1,6 +1,6 @@
 ---
 export interface Props {
-  url: string
+  url: URL
 }
 const { url } = Astro.props
 const user = url.pathname.split('/')[1]


### PR DESCRIPTION
以前作成したCodePenEmbedのPropsのurlがstring型になっていたため、URL型に修正しました。