### PR TITLE
Support Circuit Simulator Applet embed

### DIFF
--- a/src/components/notion-blocks/CircuitSimulatorAppletEmbed.astro
+++ b/src/components/notion-blocks/CircuitSimulatorAppletEmbed.astro
@@ -1,0 +1,26 @@
+---
+export interface Props {
+  url: URL
+}
+const { url } = Astro.props
+const param = url.searchParams.get('ctz')
+---
+
+<div class="circuit-simulator-applet-wrapper">
+  <iframe
+    src={`https://www.falstad.com/circuit/circuitjs.html?ctz=${param}`}
+    allowfullscreen></iframe>
+</div>
+
+<style>
+  .circuit-simulator-applet-wrapper {
+    margin: 0.4rem auto;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+  }
+  .circuit-simulator-applet-wrapper iframe {
+    width: 100%;
+    height: 100%;
+    border: 1px solid var(--fg);
+  }
+</style>

--- a/src/components/notion-blocks/Embed.astro
+++ b/src/components/notion-blocks/Embed.astro
@@ -6,6 +6,7 @@ import {
   isInstagramURL,
   isPinterestURL,
   isCodePenURL,
+  isCircuitSimulatorAppletURL,
 } from '../../lib/blog-helpers.ts'
 import Bookmark from './Bookmark.astro'
 import TweetEmbed from './TweetEmbed.astro'
@@ -13,6 +14,7 @@ import TikTokEmbed from './TikTokEmbed.astro'
 import InstagramEmbed from './InstagramEmbed.astro'
 import PinterestEmbed from './PinterestEmbed.astro'
 import CodePenEmbed from './CodePenEmbed.astro'
+import CircuitSimulatorAppletEmbed from './CircuitSimulatorAppletEmbed.astro'
 
 export interface Props {
   block: interfaces.Block
@@ -41,6 +43,8 @@ try {
       <PinterestEmbed url={url} />
     ) : isCodePenURL(url) ? (
       <CodePenEmbed url={url} />
+    ) : isCircuitSimulatorAppletURL(url) ? (
+      <CircuitSimulatorAppletEmbed url={url} />
     ) : (
       <Bookmark block={block} urlMap={urlMap} />
     )

--- a/src/lib/blog-helpers.ts
+++ b/src/lib/blog-helpers.ts
@@ -233,6 +233,14 @@ export const isGitHubURL = (url: URL): boolean => {
   return /\/[^/]+\/[^/]+\/blob\/[^/]+\/.+/.test(url.pathname)
 }
 
+export const isCircuitSimulatorAppletURL = (url: URL): boolean => {
+  if (url.hostname !== 'falstad.com' && url.hostname !== 'www.falstad.com') {
+    return false
+  }
+
+  return url.pathname === '/circuit/circuitjs.html'
+}
+
 export const isShortAmazonURL = (url: URL): boolean => {
   if (url.hostname === 'amzn.to' || url.hostname === 'www.amzn.to') {
     return true


### PR DESCRIPTION
Circuit Simulator Appletという回路シミュレータの埋め込みコンポーネントを作成しました。
画像はこちらの[リレーオシレータの回路](https://www.falstad.com/circuit/circuitjs.html?ctz=CQAgjCAMB0l3BWcAmALNZA2VAOMmB2SBVATlIQJAUmutoQFMBaMMAKDAJxEzRADMkVCAIJkg4b3BQMIZjEj4CQghRXZclCYqRh48WZAnJaisEkXEo7AMajxIVLl79nPEVYEDZAggVQBSgFMMGRTckwjJRsAdwcJbyixCXcbAHNXETS+bNIos3YAJwTBEJAcFySocBp2eJSQZBweSp5mnkh6ipcOnp5qroAlLMkRBExaIU8a1AYas2gEbtyyqNW0roB5frWQUjC9woB7fd4ZudIeS2gIWg5TkWxZyHI6XRlUwXYgA)になっています。
<img width="985" height="766" alt="image" src="https://github.com/user-attachments/assets/ff8af89e-7d9f-48ba-a2ec-189488d36703" />

このコンポーネントはかなりニッチなので使う人が少ないのではと感じています。
プロジェクトの肥大化やメンテナンスコストの観点から、astro-notion-blog本体に含めるべきでないと判断されましたら気兼ねなく却下してください。