### PR TITLE
feat: upgrade to Notion API v2026-03-11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "astro-notion-blog",
-  "version": "0.6.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-notion-blog",
-      "version": "0.6.3",
+      "version": "0.10.0",
       "dependencies": {
         "@astrojs/react": "^4.1.2",
         "@astrojs/rss": "^4.0.11",
         "@iconify-json/octicon": "^1.2.2",
-        "@notionhq/client": "^2.2.15",
+        "@notionhq/client": "^5.16.0",
         "@supercharge/promise-pool": "^3.2.0",
         "astro": "^5.1.3",
         "astro-icon": "^1.1.5",
@@ -87,7 +87,8 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.10.3.tgz",
       "integrity": "sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.4.2",
@@ -210,6 +211,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1786,16 +1788,12 @@
       }
     },
     "node_modules/@notionhq/client": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.15.tgz",
-      "integrity": "sha512-XhdSY/4B1D34tSco/GION+23GMjaS9S2zszcqYkMHo8RcWInymF6L1x+Gk7EmHdrSxNFva2WM8orhC4BwQCwgw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.16.0.tgz",
+      "integrity": "sha512-0mxHJNQBLbcG2Y4+oM+XNySr/3zKtK7FKjWhrUo8TB3WCdwtUMhvuooNmEjOo8NLL9qmKm7cCR4GtEsuTD+SNg==",
       "license": "MIT",
-      "dependencies": {
-        "@types/node-fetch": "^2.5.10",
-        "node-fetch": "^2.6.1"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@npmcli/agent": {
@@ -2866,18 +2864,9 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
       "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/prismjs": {
@@ -2891,8 +2880,7 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
@@ -3000,6 +2988,7 @@
       "integrity": "sha512-67gbfv8rAwawjYx3fYArwldTQKoYfezNUT4D5ioWetr/xCrxXxvleo3uuiFuKfejipvq+og7mjz3b0G2bVyUCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.19.1",
         "@typescript-eslint/types": "8.19.1",
@@ -3261,6 +3250,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3834,6 +3824,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4076,6 +4067,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -4623,14 +4615,14 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cytoscape": {
       "version": "3.30.4",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.4.tgz",
       "integrity": "sha512-OxtlZwQl1WbwMmLiyPSEBuzeTIQnwZhJYYWFzZ2PhEHVFwpeaqNIkUzSiso00D98qk60l8Gwon2RP304d3BJ1A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5040,6 +5032,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5638,6 +5631,7 @@
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11859,53 +11853,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-fetch-native": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
       "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
       "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/node-gyp": {
       "version": "10.3.1",
@@ -12999,6 +12951,7 @@
       "integrity": "sha512-MVIfXWJmsP28mRsSt8HeL750ifb8H5+oF2UDIxGaiJCr8fkMqhLZ7kcX9ADRk2dC8qeGKedB7UVYRfBVpEiLfA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "install-artifact-from-github": "^1.3.5",
         "nan": "^2.20.0",
@@ -13010,6 +12963,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13019,6 +12973,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -13896,6 +13851,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
       "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -15189,6 +15145,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.7.tgz",
       "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.24.2",
         "postcss": "^8.4.49",
@@ -16084,6 +16041,7 @@
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16218,6 +16176,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
       "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@astrojs/react": "^4.1.2",
     "@astrojs/rss": "^4.0.11",
     "@iconify-json/octicon": "^1.2.2",
-    "@notionhq/client": "^2.2.15",
+    "@notionhq/client": "^5.16.0",
     "@supercharge/promise-pool": "^3.2.0",
     "astro": "^5.1.3",
     "astro-icon": "^1.1.5",

--- a/scripts/blog-contents-cache.cjs
+++ b/scripts/blog-contents-cache.cjs
@@ -3,7 +3,7 @@ const { Client } = require('@notionhq/client');
 const cliProgress = require('cli-progress');
 const { PromisePool } = require('@supercharge/promise-pool');
 
-const notion = new Client({ auth: process.env.NOTION_API_SECRET });
+const notion = new Client({ auth: process.env.NOTION_API_SECRET, notionVersion: '2026-03-11' });
 
 const getAllPages = async () => {
   const params = {

--- a/scripts/blog-contents-cache.cjs
+++ b/scripts/blog-contents-cache.cjs
@@ -7,7 +7,7 @@ const notion = new Client({ auth: process.env.NOTION_API_SECRET, notionVersion: 
 
 const getAllPages = async () => {
   const params = {
-    database_id: process.env.DATABASE_ID,
+    data_source_id: process.env.DATABASE_ID,
     filter: {
       and: [
         {
@@ -28,7 +28,7 @@ const getAllPages = async () => {
 
   let results = [];
   while (true) {
-    const res = await notion.databases.query(params);
+    const res = await notion.dataSources.query(params);
 
     results = results.concat(res.results);
 

--- a/scripts/retrieve-block-children.cjs
+++ b/scripts/retrieve-block-children.cjs
@@ -2,7 +2,7 @@ const fs = require('fs');
 const { setTimeout } = require('timers/promises');
 const { Client } = require('@notionhq/client');
 
-const notion = new Client({ auth: process.env.NOTION_API_SECRET });
+const notion = new Client({ auth: process.env.NOTION_API_SECRET, notionVersion: '2026-03-11' });
 
 const requestDuration = 300;
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -58,6 +58,7 @@ import { Client, APIResponseError } from '@notionhq/client'
 
 const client = new Client({
   auth: NOTION_API_SECRET,
+  notionVersion: '2026-03-11',
 })
 
 let postsCache: Post[] | null = null
@@ -102,7 +103,7 @@ export async function getAllPosts(): Promise<Post[]> {
     const res = await retry(
       async (bail) => {
         try {
-          return (await client.databases.query(
+          return (await client.dataSources.query(
             params as any // eslint-disable-line @typescript-eslint/no-explicit-any
           )) as responses.QueryDatabaseResponse
         } catch (error: unknown) {

--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -72,7 +72,7 @@ export async function getAllPosts(): Promise<Post[]> {
   }
 
   const params: requestParams.QueryDatabase = {
-    database_id: DATABASE_ID,
+    data_source_id: DATABASE_ID,
     filter: {
       and: [
         {
@@ -428,13 +428,13 @@ export async function getDatabase(): Promise<Database> {
   }
 
   const params: requestParams.RetrieveDatabase = {
-    database_id: DATABASE_ID,
+    data_source_id: DATABASE_ID,
   }
 
   const res = await retry(
     async (bail) => {
       try {
-        return (await client.databases.retrieve(
+        return (await client.dataSources.retrieve(
           params as any // eslint-disable-line @typescript-eslint/no-explicit-any
         )) as responses.RetrieveDatabaseResponse
       } catch (error: unknown) {

--- a/src/lib/notion/request-params.ts
+++ b/src/lib/notion/request-params.ts
@@ -1,5 +1,5 @@
 export interface QueryDatabase {
-  database_id: string
+  data_source_id: string
   filter?: PropertyFilterObject | CompoundFilterObject
   sorts?: PropertyValueSortObject[]
   page_size?: number
@@ -7,7 +7,7 @@ export interface QueryDatabase {
 }
 
 export interface RetrieveDatabase {
-  database_id: string
+  data_source_id: string
 }
 
 export interface RetrieveBlock {

--- a/src/lib/notion/responses.ts
+++ b/src/lib/notion/responses.ts
@@ -137,7 +137,7 @@ interface DatabaseObject {
   properties: DatabaseProperties
   parent: Parent
   url: string
-  archived: boolean
+  in_trash: boolean
   is_inline: boolean
 }
 
@@ -237,7 +237,7 @@ export interface PageObject {
   created_by: UserObject
   last_edited_time: string
   last_edited_by: UserObject
-  archived: boolean
+  in_trash: boolean
   icon: FileObject | Emoji | null
   cover: FileObject
   properties: PageProperties
@@ -319,7 +319,7 @@ export interface BlockObject {
   created_by: UserObject
   last_edited_by: UserObject
   has_children: boolean
-  archived: boolean
+  in_trash: boolean
   type: string
 
   paragraph?: Paragraph


### PR DESCRIPTION
## Summary

- Upgrade `@notionhq/client` from v2.x to v5.x to support Notion API v2026-03-11
- Set `notionVersion: '2026-03-11'` on all `Client` instances
- Rename `archived` to `in_trash` in response type definitions
- Migrate `client.databases.query` → `client.dataSources.query` (SDK v5 API reorganization)
- Add `src/env.d.ts` with `astro/client` reference to fix `import.meta.env` TypeScript types

## Why

The Notion API v2026-03-11 introduces breaking changes. The previous API versions may be deprecated in the future. This PR ensures compatibility with the latest API version.

## Breaking changes in Notion API v2026-03-11

| Change | Impact on this project |
|---|---|
| `archived` → `in_trash` | Response type definitions updated (3 locations) |
| `databases.query` → `dataSources.query` | Client call updated in `src/lib/notion/client.ts` |
| `after` → `position` (block append) | Not affected (read-only usage) |
| `transcription` → `meeting_notes` | Not affected (not used) |

## Changes

- `package.json` — `@notionhq/client` ^2.2.15 → ^5.16.0
- `src/lib/notion/client.ts` — Added `notionVersion: '2026-03-11'`; migrated `databases.query` → `dataSources.query`
- `scripts/blog-contents-cache.cjs` — Added `notionVersion: '2026-03-11'`
- `scripts/retrieve-block-children.cjs` — Added `notionVersion: '2026-03-11'`
- `src/lib/notion/responses.ts` — `archived` → `in_trash` (3 locations)
- `src/env.d.ts` — Added `/// <reference types="astro/client" />` for TypeScript correctness

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [ ] Manual testing with Notion database (requires API token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)